### PR TITLE
Updates Docker Lesson Plan to Explicitly add 0.16.0

### DIFF
--- a/content/aut/lesson.md
+++ b/content/aut/lesson.md
@@ -32,11 +32,11 @@ Make a directory in your userspace, somewhere where you can find it: on your des
 
 Use the following command, replacing `/path/to/your/data` with the directory. **If you want to use your own ARC or WARC files, please put them in this directory**.
 
-`docker run --rm -it -v "/path/to/your/data:/data" archivesunleashed/docker-aut`
+`docker run --rm -it -v "/path/to/your/data:/data" archivesunleashed/docker-aut:0.16.0`
 
 For example, if your files are in `/Users/ianmilligan1/desktop/data` you would run the above command like:
 
-`docker run --rm -it -v "/Users/ianmilligan1/desktop/data:/data" archivesunleashed/docker-aut`
+`docker run --rm -it -v "/Users/ianmilligan1/desktop/data:/data" archivesunleashed/docker-aut:0.16.0`
 
 Once you run this command, you will have to wait a few minutes while data is downloaded and AUT builds. Once it is all working, you should see:
 


### PR DESCRIPTION
We should explicit have the Docker lesson mention 0.16.0, and this pull request updates this. 

It should be a quick easy merge, but @SamFritz can you make sure this lines up on your end?