### PR TITLE
Adds publication page, closes #102

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -83,6 +83,11 @@ googleAnalytics = "UA-2879197-28"
 	weight = 45
 
 [[menu.main]]
+	name   = "Publications"
+	url    = "publications/"
+	weight = 48
+
+[[menu.main]]
 	name   = "News (on Medium.com)"
 	url    = "https://news.archivesunleashed.org"
 	weight = 50

--- a/content/publications/index.md
+++ b/content/publications/index.md
@@ -1,0 +1,23 @@
+---
+title: "Publications"
+date: 2019-03-19T14:45:14-04:00
+weight: 48
+---
+
+The Archives Unleashed project has a body of published research. Check back for more soon!
+
+## Journal Articles
+
+* Jimmy Lin, Ian Milligan, Jeremy Wiebe, and Alice Zhou. “Warcbase: Scalable Analytics Infrastructure for Exploring Web Archives,” _ACM Journal of Computing and Cultural Heritage_, Vol. 10, Issue 4, July 2017. [[link](https://dl.acm.org/citation.cfm?id=3097570)]
+
+## Peer-Reviewed Conference Publications
+
+* Ryan Deschamps, Samantha Fritz, Jimmy Lin, Ian Milligan, and Nick Ruest. "The Cost of a WARC: Analyzing Web Archives in the Cloud." _Proceedings of the ACM/IEEE Joint Conference on Digital Libraries_, Vol. 19 (2019). Forthcoming.
+* Ian Milligan, Nathalie Casemajor, Samantha Fritz, Jimmy Lin, Nick Ruest, Matthew S. Weber, and Nicholas Worby. "Building Community and Tools for Analyzing Web Archives through Datathons." _Proceedings of the ACM/IEEE Joint Conference on Digital Libraries_, Vol. 19 (2019). Forthcoming.
+* Ian Milligan, Nick Ruest, and Jimmy Lin. "Content Selection and Curation for Web Archiving: The Gatekeepers vs. the Masses." _Proceedings of the ACM/IEEE Joint Conference on Digital Libraries_, Vol. 16 (2016): 107—110. [[link](https://dl.acm.org/citation.cfm?id=2910913)]
+* Andrew Jackson, Jimmy Lin, Ian Milligan, and Nick Ruest. "Desiderata for Exploratory Search Interfaces to Web Archives in Support of Scholarly Activities." _Proceedings of the ACM/IEEE Joint Conference on Digital Libraries_, Vol. 16 (2016): 103—106. [[link](https://dl.acm.org/citation.cfm?id=2910912)]
+
+## Peer-Reviewed Posters and Demonstrations
+
+* Hsiu-Wei Yang, Linqing Liu, Ian Milligan, Nick Ruest, and Jimmy Lin. "Scalable Content-Based Analysis of Images in Web Archives with TensorFlow and the Archives Unleashed Toolkit." _Proceedings of the ACM/IEEE Joint Conference on Digital Libraries_, Vol. 19 (2019). Forthcoming.
+* Nick Ruest, Ian Milligan, and Jimmy Lin. "Warclight: A Rails Engine for Web Archive Discovery." _Proceedings of the ACM/IEEE Joint Conference on Digital Libraries_, Vol. 19 (2019). Forthcoming.


### PR DESCRIPTION
🤦‍♂️ The branch name is incorrect. This actually addresses #102.

But it does add a publications page for the project. I've put it in the left-hand column above "news," and elected to just include project-specific publications and those things we mention a lot. 

![Screen Shot 2019-03-19 at 3 33 44 PM](https://user-images.githubusercontent.com/3834704/54636238-6268e900-4a5c-11e9-8013-b46e3e3a727c.png)
