### PR TITLE
Update new-york and events index (Issue #142)

### DIFF
--- a/content/events/index.md
+++ b/content/events/index.md
@@ -9,14 +9,15 @@ weight: 40
 
 The Archives Unleashed team will be hosting the final datathon in the spring of 2020. Will we post information here and through our channels as it becomes available. Feel free to explore past event pages to learn more about the datathon set up and checkout group projects.
 
-|        Date       |         Location         |
-|:-----------------:|:------------------------:|
-| April 26-27, 2018 | Toronto, ON              |
-| November 1-2, 2018 | Vancouver, BC       |
-| March 21-22, 2019          | Washington, DC |
-| March 26-27,202     | New York City, NY |
+|        Date       |         Location         |        Hosts             |
+|:-----------------:|:------------------------:|:------------------------:|
+| 26-27 April 2018 | Toronto, ON              | [University of Toronto Libraries](https://onesearch.library.utoronto.ca/about) |
+| 1-2 November 2018| Vancouver, BC            | [Simon Fraser University Library](https://www.lib.sfu.ca) and [KEY](https://www.sfu.ca/big-data/) | 
+| 21-22 March 2019 | Washington, DC           | [George Washington University Libraries](https://library.gwu.edu) |
+| 26-27 March 2020 | New York City, NY        | [Columbia University Libraries](https://library.columbia.edu) |
+| 14-15 May 2020   | Montreal, Quebec         | [BAnQ](http://www.banq.qc.ca/accueil/index.html?language_id=1) and [IIPC](http://netpreserve.org) |
 
-## Past Datathons
+## **Past Datathons**
 
 We have had the pleasure of hosting several datathons. The first four pre-dated our <a href="http://mellon.org">Mellon</a>-Funded Archives Unleashed project:
 
@@ -25,12 +26,16 @@ We have had the pleasure of hosting several datathons. The first four pre-dated 
 * **[Archives Unleashed 3.0](http://archivesunleashed.com/au-3-cfp/)**, Internet Archive, February 2017.
 * **[Archives Unleashed 4.0](http://archivesunleashed.com/au4-0-british-invasion/)**, British Library, June 2017.
 
-As part of this <a href="http://mellon.org">Mellon</a>-funded project, we have hosted two events:
+As part of this <a href="http://mellon.org">Mellon</a>-funded project, we have hosted three events:
 
 * **[Archives Unleashed Toronto](/toronto)**, University of Toronto, April 2018.
 * **[Archives Unleashed Vancouver](/vancouver)**, Simon Fraser University, November 2018.
 * **[Archives Unleashed Washington](/washington)**, George Washington University, March 2019.
-* **[Archives Unleashed New York](/new-york)**, Columbia University, March 2020.
+* *UPCOMING* **[Archives Unleashed New York](/new-york)**, Columbia University, 26-27 March 2020.
+
+**Additional Datathons/Workshops**:
+
+* **[Archives Unleashed Montreal](http://netpreserve.org/ga2020/datathon/)**, Montreal, QB, 14-15 May 2020. <br> This datathon directly follows the IIPC [Web Archiving Conference](http://netpreserve.org/ga2020/). Please visit the **[Montreal datathon](http://netpreserve.org/ga2020/datathon/)** event page for submission details.|
 
 ## About our Datathons
 

--- a/content/new-york/index.md
+++ b/content/new-york/index.md
@@ -16,7 +16,7 @@ The project team invites archivists, researchers (from the humanities, social sc
 
 The Archives Unleashed Team has partnered with <a href="https://library.columbia.edu">**Columbia University Libraries**</a> to host the fourth Archives Unleashed datathon.
 
-This event will bring together a small group of **approximately 15-20 participants** to experiment with the newest release of the Archives Unleashed Toolkit and Cloud, and to kick-off collaboratively inspired research projects. Participants will have access to analytics software and specialists, and will be exposed to the process of working with web archive files at scale.
+This event will bring together a small group to experiment with the newest release of the Archives Unleashed Toolkit and Cloud, and to kick-off collaboratively inspired research projects. Participants will have access to analytics software and specialists, and will be exposed to the process of working with web archive files at scale.
 
 For more information on AUT and the Cloud, please visit http://archivesunleashed.org/.
 
@@ -32,6 +32,8 @@ For more information on AUT and the Cloud, please visit http://archivesunleashed
 
 ## Sponsors
 
+This event is possible thanks to the generous support of the <a href="https://mellon.org"> Andrew W. Mellon Foundation </a>, <a href="https://library.columbia.edu">Columbia University Libraries</a>, <a href="https://library.gwu.edu"> University of Waterloo’s Faculty of Arts </a>, <a href="http://www.yorku.ca"> York University Libraries </a>, <a href="https://www.computecanada.ca"> Compute Canada</a>, and <a href="http://www.startsmartlabs.com"> Start Smart Labs</a>.
+
 ![Sponsor Logos](/images/ny-sponsors.png)
 
 
@@ -39,31 +41,19 @@ For more information on AUT and the Cloud, please visit http://archivesunleashed
 
 |        Date       |         Location         |
 |:-----------------:|:------------------------:|
-| 16 September 2019 | Call for Participation|
-| 16 October 2019 | Second Call for Participation|
-| ~~1 November 2019~~ | ~~Submissions Due~~ |
-| 5 November 2019 | **Extension** Submissions Due |
+| ~~16 September 2019~~ | ~~Call for Participation~~|
+| ~~16 October 2019~~ | ~~Second Call for Participation~~|
+| ~~5 November 2019~~ | ~~**Extension** Submissions Due~~ |
 | 12 November 2019| Applicants notified |
-
-## Call for Participation
-
-![New York Datathon Call for Participation](/images/NYCFPDeadlineExtension.png)
 
 ## Submissions
 
-Those interested in participating should submit the following to the Archives Unleashed Team (<a href="mailto:sam.fritz@archivesunleashed.org">sam.fritz@archivesunleashed.org</a>) by **midnight Eastern Standard Time** on **5 November 2019**:
+Thank you for your interest in the Archives Unleashed Datathon!
 
-* a 250-word expression of interest;
-* a short one-page CV; and
-* Indication of need for financial assistance to travel to event (if applicable)
-
-This expression of interest should address your background and interests in web archiving, and what you would hope to get out of working with tools and web archive data at scale.
-
-## Travel Grants
-
-This event is possible thanks to the generous support of the <a href="https://mellon.org"> Andrew W. Mellon Foundation </a>, <a href="https://library.columbia.edu">Columbia University Libraries</a>, <a href="https://library.gwu.edu"> University of Waterloo’s Faculty of Arts </a>, <a href="http://www.yorku.ca"> York University Libraries </a>, <a href="https://www.computecanada.ca"> Compute Canada</a>, and <a href="http://www.startsmartlabs.com"> Start Smart Labs</a>.
-
-The Archives Unleashed team is pleased to offer modest travel grants to help attendees participate in this event. These grants can cover **up to $1,000 USD** in travel expenses. If you require financial assistance to attend the event, please explicitly indicate in your statement of interest that you would like to be considered for the travel grant.
+|        Date       |         Location         |         Datathon         |
+|:-----------------:|:------------------------:|:------------------------:|
+| 26-27 March 2020  | Columbia University, <br>New York | Submissions are now **closed**|
+| 14-15 May 2020    | Montreal, Quebec | Call for Participation **open** until <br>1 Dec 2019 @ midnight (EST). <br><br>**Note:** The Montreal datathon directly follows the IIPC [Web Archiving Conference](http://netpreserve.org/ga2020/). Please visit the **[Montreal datathon](http://netpreserve.org/ga2020/datathon/)** event page for submission details.|
 
 
 <!---
@@ -73,6 +63,7 @@ Datathon Page Outline:
 ## Organizers
 ## Sponsors
 ** Important Dates**
+## Call for Participation
 ## Sumbissions
 ## Travel Grants
 ## Venu
@@ -83,8 +74,22 @@ Datathon Page Outline:
 
 _________________________________________________________________________________
 
+
+## Call for Participation
+
+![New York Datathon Call for Participation](/images/NYCFPDeadlineExtension.png)
+
+
 ## Submissions
 Thank you for your interest in the Archives Unleashed Datathon, submissions for the March 26-27 New York Datathon are now closed.
+
+Those interested in participating should submit the following to the Archives Unleashed Team (<a href="mailto:sam.fritz@archivesunleashed.org">sam.fritz@archivesunleashed.org</a>) by **midnight Eastern Standard Time** on **5 November 2019**:
+
+* a 250-word expression of interest;
+* a short one-page CV; and
+* Indication of need for financial assistance to travel to event (if applicable)
+
+This expression of interest should address your background and interests in web archiving, and what you would hope to get out of working with tools and web archive data at scale.
 
 
 ## Venue


### PR DESCRIPTION
This PR addressed[ Issue #142 (Update Datathons Events)](https://github.com/archivesunleashed/archivesunleashed.org/issues/142) and completes the following:

**NY Datathon Page (new-work index.md)**
- removes submission details
- adds notice that submissions now are closed
- general clean up of text
- notes Montreal CFP is open + short description
- re-structures sponsor list section so blurb is above logo images

**Events Page (events index.md)**
- adds host column to overall event listing to highlight our hosts better
- General formatting of headers + tables
- indicates NY event under Mellon is upcoming
- creates new header:  Upcoming Datathons/Workshops 
- highlights Montreal datathon and outbound link for submissions

General review to make sure nothing has been missed, many thanks @ianmilligan1 
Travel info, etc. will be added in separate PR in a few weeks. 