### PR TITLE
Adds travel information to NY Event page

### DIFF
--- a/content/new-york/index.md
+++ b/content/new-york/index.md
@@ -8,11 +8,9 @@ aliases:
 
 ![New York Skyline](/images/ny-save.png)
 
-## About
+## **About**
 
-The World Wide Web has had a profound impact on how we research and understand the past. The sheer amount of cultural information that is generated and, crucially, preserved every day in electronic form, presents exciting new opportunities for researchers. Much of this information is captured within web archives.
-
-The project team invites archivists, researchers (from the humanities, social sciences, and beyond), librarians, computer scientists, and web archiving enthusiasts to join us over the course of two days to collaboratively work with web collections and explore cutting-edge research tools through hands-on experience.
+We invites archivists, researchers (from the humanities, social sciences, and beyond), librarians, computer scientists, and web archiving enthusiasts to join us over the course of two days to collaboratively work with web collections and explore cutting-edge research tools through hands-on experience.
 
 The Archives Unleashed Team has partnered with <a href="https://library.columbia.edu">**Columbia University Libraries**</a> to host the fourth Archives Unleashed datathon.
 
@@ -20,7 +18,7 @@ This event will bring together a small group to experiment with the newest relea
 
 For more information on AUT and the Cloud, please visit http://archivesunleashed.org/.
 
-## Organizers
+## **Organizers**
 
 * Ian Milligan (University of Waterloo)
 * Pamela Graham (Columbia University)
@@ -30,7 +28,7 @@ For more information on AUT and the Cloud, please visit http://archivesunleashed
 * Jimmy Lin (University of Waterloo)
 * Samantha Fritz (University of Waterloo)
 
-## Sponsors
+## **Sponsors**
 
 This event is possible thanks to the generous support of the <a href="https://mellon.org"> Andrew W. Mellon Foundation </a>, <a href="https://library.columbia.edu">Columbia University Libraries</a>, <a href="https://library.gwu.edu"> University of Waterloo’s Faculty of Arts </a>, <a href="http://www.yorku.ca"> York University Libraries </a>, <a href="https://www.computecanada.ca"> Compute Canada</a>, and <a href="http://www.startsmartlabs.com"> Start Smart Labs</a>.
 
@@ -46,14 +44,107 @@ This event is possible thanks to the generous support of the <a href="https://me
 | ~~5 November 2019~~ | ~~**Extension** Submissions Due~~ |
 | 12 November 2019| Applicants notified |
 
-## Submissions
+## **Submissions**
 
-Thank you for your interest in the Archives Unleashed Datathon!
+Thank you for your interest in the Archives Unleashed Datathon! Submissions to attend the March 2020 event at Columbia University, NY have **closed.**
 
-|        Date       |         Location         |         Datathon         |
-|:-----------------:|:------------------------:|:------------------------:|
-| 26-27 March 2020  | Columbia University, <br>New York | Submissions are now **closed**|
-| 14-15 May 2020    | Montreal, Quebec | Call for Participation **open** until <br>1 Dec 2019 @ midnight (EST). <br><br>**Note:** The Montreal datathon directly follows the IIPC [Web Archiving Conference](http://netpreserve.org/ga2020/). Please visit the **[Montreal datathon](http://netpreserve.org/ga2020/datathon/)** event page for submission details.|
+However, you may want to checkout:
+
+* **Montreal Datathon, 14-15 May 2020**. Call for Participation is **open** until **1 Dec 2019 @ midnight (EST)**. This event directly follows the IIPC [Web Archiving Conference](http://netpreserve.org/ga2020/). Please visit the **[Montreal datathon](http://netpreserve.org/ga2020/datathon/)** event page for submission details.
+
+
+## **Venue**
+
+Columbia University | Butler Library | 535 West 114th St., New York, NY 10027, USA
+
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d6039.96275808335!2d-73.96541404909422!3d40.8064029792134!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c2f63c31da1355%3A0xf11ddb8a69ec829b!2sButler%20Library!5e0!3m2!1sen!2sca!4v1567542633671!5m2!1sen!2sca" width="900" height="400" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
+
+## **Butler Library**
+
+The Butler Library is located at the south end of the Morning Side campus. The only public entrance is available through the campus side. [General directions] (https://library.columbia.edu/libraries/butler/directions.html) to the Butler Library are provided by Columbia University Libraries. The closest transit stops include  subway station (#1) or bus stop (M104, M4, M60).
+
+Once you arrive at the Butler Library, you will need to check-in at the Library Information Office with a piece of ID, which is just inside the entrance, and then you can head to Room 203.<img src="/images/butler-floorplan.png"></a>
+
+## **Travel to New York**
+
+The Archives Unleashed team has put together some information and resources to help with your travel plans.
+
+![Accommodations](/images/accommodations.png)
+
+There are many choices for accommodations in the NY area! We encourage all of our out-of-town participants to check out the [MTA - New York City Transit Map](http://www.mta.info/nyct) to help spot areas close to campus. The Butler Library is located near Columbia's main gate at W. 116th St and Broadway.
+
+If staying outside the city center, we'd recommend sticking to areas nearby.
+
+Staying in New York City doesn’t have to break the bank, which is why we like using some of the following aggregators to compare hotel rates:
+
+* [Airbnb](https://www.airbnb.ca)
+* [Kayak](https://www.ca.kayak.com)
+* [Expedia](https://www.expedia.ca)
+* [Trivago](https://www.trivago.ca)
+* [Travelocity](https://www.travelocity.ca)
+
+![Airports](/images/airports.png)
+
+For guests flying into New York, there are three main airports with several options for reaching downtown.
+
+| Airport                                     | Distance to Columbia University |                                      Notes                                     |
+|---------------------------------------------|:-------------------------------:|:------------------------------------------------------------------------------:|
+| [John F. Kennedy International Airport (JFK)](https://www.jfkairport.com) |            ~ 17 Miles           | Located in Queens and primarily handles international flights                  |
+| [LaGuardia Airport (LGA)](https://www.laguardiaairport.com)                     |            ~ 8 Miles            | Located in Queens and mainly handles domestic flights                          |
+| [Newark International Airport (EWR)](https://www.newarkairport.com)         |            ~ 20 Miles           | Newark, in Newark, New Jersey, handles both domestic and international flights | 
+
+
+There are several options for getting to the downtown core from each airport, including by subway, bus, taxi, and shared vehical.
+
+* **[JFK Airport Transportation](https://www.jfkairport.com/to-from-airport/public-transportation)**
+  * [Airtrain](https://www.jfkairport.com/to-from-airport/air-train) - provides transportation around the airport.
+  * [Public Transportation](https://www.jfkairport.com/to-from-airport/public-transportation) - The AirTrain links all passenger terminals with NYC’s Subway. AirTrain fares are separate from Subway, but can both be paid using the MetroCard. Detailed transportation options to Manhatten can be found [here](https://www.jfkairport.com/to-from-airport/public-transportation); fares start at $2.75USD.
+  * [Taxi](https://www.jfkairport.com/to-from-airport/taxi-car-and-van-service) - stands are located outside each terminal. Taxis at JFK Airport charge a flat fare of $52 for trips between the airport and Manhattan (tolls and tips not included). Be sure to check out taxi tips provided on the [JFK webpage](https://www.jfkairport.com/to-from-airport/taxi-car-and-van-service).
+  * [Car, Van and Scheduled Bus Service ](https://www.jfkairport.com/to-from-airport/taxi-car-and-van-service) - Reservations can be made at the Port Authority Welcome Center located on the Arrivals level of each terminal. Individual car rentals are also available.
+
+* **[LaGuardia Airport Transportation](https://www.laguardiaairport.com/to-from-airport/public-transportation)**
+  * [Metropolitan Transportation Authority (MTA)](https://www.laguardiaairport.com/to-from-airport/public-transportation) - buses and connection to the subway for service between LaGuardia Airport, Manhattan, Queens and beyond. A one-way trip on MTA buses or subways costs $2.75USD. MetroCards can be purchased at MetroCard vending machines throughout Airport terminals.
+  * Metered [taxi service](https://www.laguardiaairport.com/to-from-airport/by-taxi) is available at all LaGuardia Airport terminal buildings.
+  * [Car or Shared ride service](https://www.laguardiaairport.com/to-from-airport/car-service-and-shared-rides) - reservation for a private car or various shared ride service can be made through the Welcome Center located on the arrivals level of each terminal.
+
+* **[Newark Airport Transportation](https://www.newarkairport.com/to-from-airport/airport-directions)**
+  * [Airtrain](https://www.newarkairport.com/to-from-airport/air-train) - provides transportation to, from, and around Newark Liberty International Airport, and offers an accessible option to get to and from Manhattan. For more information on schedules, maps, and fees, please checkout the [Airtrain Website](https://www.newarkairport.com/to-from-airport/air-train).
+  * [Public Transportation](https://www.newarkairport.com/to-from-airport/public-transportation) - There are several options both to and from Newark via public transportation.
+  * [Taxi](https://www.newarkairport.com/to-from-airport/taxi-car-and-van-service) - To use ground transportation, vists the Port Authority Welcome Center located in the arrivals area of each terminal. Rates will depend on drop off location; fare to New York City/Manhattan area ranges from $50-70USD, not including tolls or tips.
+  * [Car, Van and Scheduled Bus Service ](https://www.newarkairport.com/to-from-airport/taxi-car-and-van-service) - Reservations can also be made directly at the Port Authority Welcome Center located on the Arrivals level of each terminal. A number of options are available.
+
+
+![Downtown Transit](/images/transit.png)
+
+While you are in New York there are a few ways to get around, but ultimately it will depend on how close you are to the University. The Butler Library is located at the south end of the Morning Side campus (near Columbia's main gate at W. 116th St and Broadway) and is easily accessible by public transportation or by foot from most areas of downtown New York.
+
+* **Public Transport**
+  * MTA Subways and Buses - Pay-per-ride MetroCard, a single subway or local bus ride costs $2.75USD for standard buses, and $6.50USd for express buses. Fares can be paid in cash or by[MetroCard](http://web.mta.info/metrocard/). You can purchase MetroCard at all subway stations, at the Station Booth or at MetroCard Vending Machines. You will need to put a minimum value of $5.50 on the card, not including the card fee ($1).
+
+* **Rideshare Apps** - - [Uber](https://www.uber.com/global/en/cities/new-york/) and [Lyft](https://www.lyft.com/rider/cities/new-york-city-ny) are available in New York City, NY. You can download the apps and book a ride easily.
+
+* **Taxis** - Want to ride in the iconic Yellow Taxi? Fun fact, these yellow taxis are the only vehicles that are allowed to pick passengers up in response to a street hail across the entire city [Cite 1](https://www.findingtheuniverse.com/how-to-get-around-new-york-city-a-guide-to-nyc-transport-options/).
+
+![Attractions](/images/attractions.png)
+
+For those adventurers who’d like to check out New York attractions, you may want to check out the [Official Visitor's Guide to New York City](https://www.nycgo.com). Some of our favourite spots to visit include:
+
+* [Empire State Building Observatory](https://www.esbnyc.com) - check out the stunning 360 view of the city from a building that has its own zip code!
+* [Statue of Liberty](https://www.nps.gov/stli/index.htm) - this iconic statue was a gift from the French in 1886 as a symbol of freedom and democracy. Visitors can tour the pedestal or crown!
+* [Times Square](https://www.timessquarenyc.org) - there's never a dull moment when you visit what has been referred to as "The Crossroads of the World".
+* [Central Park](http://www.centralparknyc.org) - this urban park covers 843 acres and includes various landscapes (geological, wooded areas and watercourses), landmarks, sculptures, exhibits, recreational facilities, and is home to over 571 species. 
+* [The Met](https://www.metmuseum.org) - Visit the largest art museum in the world, home to over two million works.
+* [Rockefeller Center](https://www.rockefellercenter.com) - this urban complex stretch over 22 acres, was constructed during the Depression Era and is home to several landmark buildings including Radio City and original Art Deco structures.
+* [Yankee Stadium](https://www.mlb.com/yankees/ballpark) - catch a game or tour!
+* [Brooklyn Bridge](https://www1.nyc.gov/html/dot/html/infrastructure/brooklyn-bridge.shtml) - you can view, walk [tips](https://freetoursbyfoot.com/walking-the-brooklyn-bridge/), or cycle this beautiful 136 year old landmark.
+* [Staten Island Ferry](https://www.siferry.com) - enjoy a beautiful ride along the New York Harbour.
+
+
+## **Schedule**
+
+Coming Soon! 
+
+(For those that need a general timeline for travel planning, please note the event will run 9:00 - 5:00pm on Thursday and 9:00 - 4:40pm on Friday).
 
 
 <!---

--- a/content/new-york/index.md
+++ b/content/new-york/index.md
@@ -10,7 +10,7 @@ aliases:
 
 ## **About**
 
-We invites archivists, researchers (from the humanities, social sciences, and beyond), librarians, computer scientists, and web archiving enthusiasts to join us over the course of two days to collaboratively work with web collections and explore cutting-edge research tools through hands-on experience.
+We invite archivists, researchers (from the humanities, social sciences, and beyond), librarians, computer scientists, and web archiving enthusiasts to join us over the course of two days to collaboratively work with web collections and explore cutting-edge research tools through hands-on experience.
 
 The Archives Unleashed Team has partnered with <a href="https://library.columbia.edu">**Columbia University Libraries**</a> to host the fourth Archives Unleashed datathon.
 
@@ -46,7 +46,7 @@ This event is possible thanks to the generous support of the <a href="https://me
 
 ## **Submissions**
 
-Thank you for your interest in the Archives Unleashed Datathon! Submissions to attend the March 2020 event at Columbia University, NY have **closed.**
+Thank you for your interest in the Archives Unleashed Datathon! Submissions to attend the March 2020 event at Columbia University, NY have now **closed.**
 
 However, you may want to checkout:
 
@@ -61,7 +61,7 @@ Columbia University | Butler Library | 535 West 114th St., New York, NY 10027, U
 
 ## **Butler Library**
 
-The Butler Library is located at the south end of the Morning Side campus. The only public entrance is available through the campus side. [General directions] (https://library.columbia.edu/libraries/butler/directions.html) to the Butler Library are provided by Columbia University Libraries. The closest transit stops include  subway station (#1) or bus stop (M104, M4, M60).
+The Butler Library is located at the south end of the Morning Side campus. The only public entrance is available through the campus side. [General directions](https://library.columbia.edu/libraries/butler/directions.html) to the Butler Library are provided by Columbia University Libraries. The closest transit stops include subway station (#1) or bus stop (M104, M4, M60).
 
 Once you arrive at the Butler Library, you will need to check-in at the Library Information Office with a piece of ID, which is just inside the entrance, and then you can head to Room 203.<img src="/images/butler-floorplan.png"></a>
 
@@ -71,9 +71,7 @@ The Archives Unleashed team has put together some information and resources to h
 
 ![Accommodations](/images/accommodations.png)
 
-There are many choices for accommodations in the NY area! We encourage all of our out-of-town participants to check out the [MTA - New York City Transit Map](http://www.mta.info/nyct) to help spot areas close to campus. The Butler Library is located near Columbia's main gate at W. 116th St and Broadway.
-
-If staying outside the city center, we'd recommend sticking to areas nearby.
+There are many choices for accommodations in the NY area! We encourage all of our out-of-town participants to check out the [MTA - New York City Transit Map](http://www.mta.info/nyct) to help spot areas close to campus and transit lines. The Butler Library is located near Columbia's main gate at W. 116th St and Broadway.
 
 Staying in New York City doesn’t have to break the bank, which is why we like using some of the following aggregators to compare hotel rates:
 

--- a/content/new-york/index.md
+++ b/content/new-york/index.md
@@ -48,7 +48,7 @@ This event is possible thanks to the generous support of the <a href="https://me
 
 Thank you for your interest in the Archives Unleashed Datathon! Submissions to attend the March 2020 event at Columbia University, NY have now **closed.**
 
-However, you may want to checkout:
+However, you may want to check out:
 
 * **Montreal Datathon, 14-15 May 2020**. Call for Participation is **open** until **1 Dec 2019 @ midnight (EST)**. This event directly follows the IIPC [Web Archiving Conference](http://netpreserve.org/ga2020/). Please visit the **[Montreal datathon](http://netpreserve.org/ga2020/datathon/)** event page for submission details.
 
@@ -61,9 +61,9 @@ Columbia University | Butler Library | 535 West 114th St., New York, NY 10027, U
 
 ## **Butler Library**
 
-The Butler Library is located at the south end of the Morning Side campus. The only public entrance is available through the campus side. [General directions](https://library.columbia.edu/libraries/butler/directions.html) to the Butler Library are provided by Columbia University Libraries. The closest transit stops include subway station (#1) or bus stop (M104, M4, M60).
+The Butler Library is located at the south end of the Morningside campus. The only public entrance is available through the campus side. [General directions](https://library.columbia.edu/libraries/butler/directions.html) to the Butler Library are provided by Columbia University Libraries. The closest transit stops include the West 116th Street subway station (on the 1 train) or bus stop (M104, M4, M60).
 
-Once you arrive at the Butler Library, you will need to check-in at the Library Information Office with a piece of ID, which is just inside the entrance, and then you can head to Room 203.<img src="/images/butler-floorplan.png"></a>
+Once you arrive at the Butler Library, you will need to check in at the Library Information Office with a piece of ID, which is just inside the entrance, and then you can head to Room 203.<img src="/images/butler-floorplan.png"></a>
 
 ## **Travel to New York**
 
@@ -92,11 +92,11 @@ For guests flying into New York, there are three main airports with several opti
 | [Newark International Airport (EWR)](https://www.newarkairport.com)         |            ~ 20 Miles           | Newark, in Newark, New Jersey, handles both domestic and international flights | 
 
 
-There are several options for getting to the downtown core from each airport, including by subway, bus, taxi, and shared vehical.
+There are several options for getting to the downtown core from each airport, including by subway, bus, taxi, and shared vehicle.
 
 * **[JFK Airport Transportation](https://www.jfkairport.com/to-from-airport/public-transportation)**
-  * [Airtrain](https://www.jfkairport.com/to-from-airport/air-train) - provides transportation around the airport.
-  * [Public Transportation](https://www.jfkairport.com/to-from-airport/public-transportation) - The AirTrain links all passenger terminals with NYC’s Subway. AirTrain fares are separate from Subway, but can both be paid using the MetroCard. Detailed transportation options to Manhatten can be found [here](https://www.jfkairport.com/to-from-airport/public-transportation); fares start at $2.75USD.
+  * [AirTrain](https://www.jfkairport.com/to-from-airport/air-train) - provides transportation around the airport and to subway and LIRR connections.
+  * [Public Transportation](https://www.jfkairport.com/to-from-airport/public-transportation) - The AirTrain links all passenger terminals with NYC’s Subway. AirTrain fares are separate from Subway, but can both be paid using the MetroCard. Detailed transportation options to Manhattan can be found [here](https://www.jfkairport.com/to-from-airport/public-transportation); fares start at $2.75USD.
   * [Taxi](https://www.jfkairport.com/to-from-airport/taxi-car-and-van-service) - stands are located outside each terminal. Taxis at JFK Airport charge a flat fare of $52 for trips between the airport and Manhattan (tolls and tips not included). Be sure to check out taxi tips provided on the [JFK webpage](https://www.jfkairport.com/to-from-airport/taxi-car-and-van-service).
   * [Car, Van and Scheduled Bus Service ](https://www.jfkairport.com/to-from-airport/taxi-car-and-van-service) - Reservations can be made at the Port Authority Welcome Center located on the Arrivals level of each terminal. Individual car rentals are also available.
 
@@ -106,7 +106,7 @@ There are several options for getting to the downtown core from each airport, in
   * [Car or Shared ride service](https://www.laguardiaairport.com/to-from-airport/car-service-and-shared-rides) - reservation for a private car or various shared ride service can be made through the Welcome Center located on the arrivals level of each terminal.
 
 * **[Newark Airport Transportation](https://www.newarkairport.com/to-from-airport/airport-directions)**
-  * [Airtrain](https://www.newarkairport.com/to-from-airport/air-train) - provides transportation to, from, and around Newark Liberty International Airport, and offers an accessible option to get to and from Manhattan. For more information on schedules, maps, and fees, please checkout the [Airtrain Website](https://www.newarkairport.com/to-from-airport/air-train).
+  * [AirTrain](https://www.newarkairport.com/to-from-airport/air-train) - provides transportation to, from, and around Newark Liberty International Airport, and can connect you to NJ Transit.
   * [Public Transportation](https://www.newarkairport.com/to-from-airport/public-transportation) - There are several options both to and from Newark via public transportation.
   * [Taxi](https://www.newarkairport.com/to-from-airport/taxi-car-and-van-service) - To use ground transportation, vists the Port Authority Welcome Center located in the arrivals area of each terminal. Rates will depend on drop off location; fare to New York City/Manhattan area ranges from $50-70USD, not including tolls or tips.
   * [Car, Van and Scheduled Bus Service ](https://www.newarkairport.com/to-from-airport/taxi-car-and-van-service) - Reservations can also be made directly at the Port Authority Welcome Center located on the Arrivals level of each terminal. A number of options are available.
@@ -114,7 +114,7 @@ There are several options for getting to the downtown core from each airport, in
 
 ![Downtown Transit](/images/transit.png)
 
-While you are in New York there are a few ways to get around, but ultimately it will depend on how close you are to the University. The Butler Library is located at the south end of the Morning Side campus (near Columbia's main gate at W. 116th St and Broadway) and is easily accessible by public transportation or by foot from most areas of downtown New York.
+While you are in New York there are a few ways to get around, but ultimately it will depend on how close you are to the University. The Butler Library is located at the south end of the Morningside campus (near Columbia's main gate at W. 116th St and Broadway) and is easily accessible by public transportation or by foot from most areas of downtown New York.
 
 * **Public Transport**
   * MTA Subways and Buses - Pay-per-ride MetroCard, a single subway or local bus ride costs $2.75USD for standard buses, and $6.50USd for express buses. Fares can be paid in cash or by[MetroCard](http://web.mta.info/metrocard/). You can purchase MetroCard at all subway stations, at the Station Booth or at MetroCard Vending Machines. You will need to put a minimum value of $5.50 on the card, not including the card fee ($1).
@@ -127,7 +127,7 @@ While you are in New York there are a few ways to get around, but ultimately it 
 
 For those adventurers who’d like to check out New York attractions, you may want to check out the [Official Visitor's Guide to New York City](https://www.nycgo.com). Some of our favourite spots to visit include:
 
-* [Empire State Building Observatory](https://www.esbnyc.com) - check out the stunning 360 view of the city from a building that has its own zip code!
+* [Empire State Building Observatory](https://www.esbnyc.com) - check out the stunning 360 degree view of the city from a building that has its own zip code!
 * [Statue of Liberty](https://www.nps.gov/stli/index.htm) - this iconic statue was a gift from the French in 1886 as a symbol of freedom and democracy. Visitors can tour the pedestal or crown!
 * [Times Square](https://www.timessquarenyc.org) - there's never a dull moment when you visit what has been referred to as "The Crossroads of the World".
 * [Central Park](http://www.centralparknyc.org) - this urban park covers 843 acres and includes various landscapes (geological, wooded areas and watercourses), landmarks, sculptures, exhibits, recreational facilities, and is home to over 571 species. 
@@ -189,7 +189,7 @@ Columbia University | Butler Library | 535 West 114th St., New York, NY 10027, U
 
 ## Butler Library 
 
-The Butler Library is located at the south end of the Morning Side campus. The only public entrance is available through the campus side. [General directions] (https://library.columbia.edu/libraries/butler/directions.html) to the Butler Library are provided by Columbia University Libraries. The closest transit stops include  subway station (#1) or bus stop (M104, M4, M60).
+The Butler Library is located at the south end of the Morningside campus. The only public entrance is available through the campus side. [General directions] (https://library.columbia.edu/libraries/butler/directions.html) to the Butler Library are provided by Columbia University Libraries. The closest transit stops include  subway station (#1) or bus stop (M104, M4, M60).
 
 Once you arrive at the Butler Library, you will need to check-in at the Library Information Office with a piece of ID, which is just inside the entrance, and then you can head to Room 203<img src="/images/butler-floorplan.png"></a>.
 
@@ -226,7 +226,7 @@ There are several options for getting to the downtown core from each airport, in
 
 * [JFK Airport Transportation](https://www.jfkairport.com/to-from-airport/public-transportation)
   * [Airtrain](https://www.jfkairport.com/to-from-airport/air-train) - provides transportation around the airport
-  * [Public Transportation](https://www.jfkairport.com/to-from-airport/public-transportation) - The AirTrain links all passenger terminals with NYC’s Subway. AirTrain fares are separate from Subway, but can both be paid using the MetroCard. Detailed transportation options to Manhatten can be found [here](https://www.jfkairport.com/to-from-airport/public-transportation); fares start at $2.75USD.
+  * [Public Transportation](https://www.jfkairport.com/to-from-airport/public-transportation) - The AirTrain links all passenger terminals with NYC’s Subway. AirTrain fares are separate from Subway, but can both be paid using the MetroCard. Detailed transportation options to Manhattan can be found [here](https://www.jfkairport.com/to-from-airport/public-transportation); fares start at $2.75USD.
   * [Taxi](https://www.jfkairport.com/to-from-airport/taxi-car-and-van-service) - stands are located outside each terminal. Taxis at JFK Airport charge a flat fare of $52 for trips between the airport and Manhattan (tolls and tips not included). Be sure to check out taxi tips provided on the [JFK webpage](https://www.jfkairport.com/to-from-airport/taxi-car-and-van-service)
   * [Car, Van and Scheduled Bus Service ](https://www.jfkairport.com/to-from-airport/taxi-car-and-van-service) - Reservations can be made at the Port Authority Welcome Center located on the Arrivals level of each terminal. Individual car rentals are also available.
 
@@ -244,7 +244,7 @@ There are several options for getting to the downtown core from each airport, in
 
 ![Downtown Transit](/images/transit.png)
 
-While you are in New York there are a few ways to get around, but ultimately it will depend on how close you are to the University. The Butler Library is located at the south end of the Morning Side campus (near Columbia's main gate at W. 116th St and Broadway). and is easily accessible by public transportation or by foot from most areas of downtown New York.
+While you are in New York there are a few ways to get around, but ultimately it will depend on how close you are to the University. The Butler Library is located at the south end of the Morningside campus (near Columbia's main gate at W. 116th St and Broadway). and is easily accessible by public transportation or by foot from most areas of downtown New York.
 
 * **Public Transport** - 
 
@@ -257,7 +257,7 @@ While you are in New York there are a few ways to get around, but ultimately it 
 
 For those adventurers who’d like to check out New York attractions, you may want to check out the [Official Visitor's Guide to New York City](https://www.nycgo.com). Some of our favourite spots to visit include:
 
-* [Empire State Building Observatory](https://www.esbnyc.com) - check out the stunning 360 view of the city from a building that has its own zip code!
+* [Empire State Building Observatory](https://www.esbnyc.com) - check out the stunning 360 degree view of the city from a building that has its own zip code!
 * [Statue of Liberty](https://www.nps.gov/stli/index.htm) - this iconic statue was a gift from the French in 1886 as a symbol of freedom and democracy. Visitors can tour the pedestal or crown!
 * [Times Square](https://www.timessquarenyc.org) - there's never a dull moment when you visit what has been referred to as "The Crossroads of the World".
 * [Central Park](http://www.centralparknyc.org) - this urban park covers 843 acres and includes various landscapes (geological, wooded areas and watercourses), landmarks, sculptures, exhibits, recreational facilities, and is home to over 571 species. 


### PR DESCRIPTION
Addresses [Issue #135 ](https://github.com/archivesunleashed/archivesunleashed.org/issues/135)

Adds in travel information and includes the following sections

- Venu
- Floor plans + maps
- Travel to NY
-  Accommodations
- Airports
- Transit to Downtown
- Public Transportation
- Attractions
- Schedule: Note about general schedule has also been added (Thurs. 9-5pm) + (Fri. 9-4:30pm). Full schedule PDF to be added in the coming weeks.

If @ianmilligan1 and @ruebot could do a once over to see if there is anything missing, especially around transport options. Thanks so much for the reviewing assist. 