### PR TITLE
NY Datathon Materials

### DIFF
--- a/content/publications/index.md
+++ b/content/publications/index.md
@@ -10,7 +10,7 @@ The Archives Unleashed project has a body of published research.
 
 * Archives Unleashed. "AU NY Datathon (Online)." Online video clip. _YouTube_, 26-27 March 2020. https://youtu.be/Io6RvhqHfe4 
 
-* Ian Milligan, Nick Ruest, Jimmy Lin, Samantha Fritz. "Archives Unleashed New York Datathon: Introduction." _Archives Unleashed NY Datathon_, March 2020, Online. [[Datathon Slides](/images/AU-NY-IntroSlides-reduced.pdf")]
+* Ian Milligan, Nick Ruest, Jimmy Lin, and Samantha Fritz. "Archives Unleashed New York Datathon: Introduction." _Archives Unleashed NY Datathon_, March 2020, Online. [[Datathon Slides](/images/AU-NY-IntroSlides-reduced.pdf")]
 
 ## Preprints
 

--- a/content/publications/index.md
+++ b/content/publications/index.md
@@ -6,6 +6,12 @@ weight: 48
 
 The Archives Unleashed project has a body of published research.
 
+## Datathon Materials
+
+* Archives Unleashed. "AU NY Datathon (Online)." Online video clip. _YouTube_, 26-27 March 2020. https://youtu.be/Io6RvhqHfe4 
+
+* Ian Milligan, Nick Ruest, Jimmy Lin, Samantha Fritz. "Archives Unleashed New York Datathon: Introduction." _Archives Unleashed NY Datathon_, March 2020, Online. [[Datathon Slides](/images/AU-NY-IntroSlides-reduced.pdf")]
+
 ## Preprints
 
 * Nick Ruest, Jimmy Lin, Ian Milligan, and Samantha Fritz. "The Archives Unleashed Project: Technology, Process, and Community to Improve Scholarly Access to Web Archives." arXiv:2001.05399, January 2020. [[link](https://arxiv.org/abs/2001.05399)]


### PR DESCRIPTION
This PR addressed issue [#158: AU NY Post Datathon Materials](url)

- [ ] Add in new section to Publications page: "Datathon Materials"
- [ ] Add in AU NY datathon intro video citation and link
- [ ] Add in AU NY datathon intro slide citation and link

@ianmilligan1 if you wouldn't mind having a look to see if anything should be adjusted? Thanks for compressing the .pdf file, worked like a charm!