### PR TITLE
Remove links to WALK partners instances.

### DIFF
--- a/content/warclight/index.md
+++ b/content/warclight/index.md
@@ -4,11 +4,11 @@ date: 2017-11-14T09:21:11-05:00
 weight: 25
 ---
 
-[Warclight](https://github.com/archivesunleashed/warclight) is a [Project Blacklight](http://projectblacklight.org/) based [Rails engine](http://guides.rubyonrails.org/engines.html) that supports the discovery of web archives held in the WARC and ARC formats. It allows faceted full-text search, record view, and other advanced discovery options. Warclight is designed to work with web archive data that is indexed via the UK Web Archive's [webarchive-discovery](https://github.com/ukwa/webarchive-discovery) project.
+[Warclight](https://github.com/archivesunleashed/warclight) is a [Project Blacklight](http://projectblacklight.org/) based [Rails engine](http://guides.rubyonrails.org/engines.html) that supports the discovery of web archives held in the WARC and ARC formats. It allows faceted full-text search, record view, and other advanced discovery options. Warclight is designed to work with web archive data that is indexed via the UK Web Archive's [webarchive-discovery](https://github.com/ukwa/webarchive-discovery) project. This project grew out of the [WALK Project](https://uwaterloo.ca/web-archive-group/news/compute-canada-grant-web-archives-longitudinal-knowledge).
 
 ![Warclight screenshot](/images/warclight.png)
 
-You can visit our demo site [here](http://warclight.archivesunleashed.org), or check out the code on [GitHub](https://github.com/archivesunleashed/warclight) along with [documentation](https://github.com/archivesunleashed/warclight/wiki) to get you started on your own Warclight application.
+You can visit our demo site [here](https://warclight.archivesunleashed.org), or check out the code on [GitHub](https://github.com/archivesunleashed/warclight) along with [documentation](https://github.com/archivesunleashed/warclight/wiki) to get you started on your own Warclight application.
 
 Want to know more?
 
@@ -17,12 +17,3 @@ We have a few posts about Warclight at [news.archivesunleashed.org](https://news
   - [See a Little Warclight](https://news.archivesunleashed.org/see-a-little-warclight-7b33059355f2)
   - [Warclight and WALK: Providing a Framework for Search and Discovery of Web Archives](https://news.archivesunleashed.org/warclight-and-walk-providing-a-framework-for-search-and-discovery-of-web-archives-47fbd469da2d)
   - [Thumbnails in Warclight](https://news.archivesunleashed.org/thumbnails-in-warclight-e155a0910c35)
-
-We also have Warclight instances setup for each of our [WALK Partners](https://uwaterloo.ca/web-archive-group/news/compute-canada-grant-web-archives-longitudinal-knowledge):
-
-  - [Dalhousie University](http://dalhousie.archivesunleashed.org/)
-  - [Simon Fraser University](http://sfu.archivesunleashed.org/)
-  - [University of Alberta](http://ualberta.archivesunleashed.org)
-  - [University of Toronto](http://utoronto.archivesunleashed.org/)
-  - [University of Victoria](http://uvic.archivesunleashed.org/)
-  - [University of Winnipeg](http://uwinnipeg.archivesunleashed.org/)


### PR DESCRIPTION
I'll move this out of draft after October 31 once I shut all the WALK partner instances down, and our SolrCloud cluster.