### PR TITLE
Adds in cohort project teams and descriptions

### DIFF
--- a/content/cohorts/index.md
+++ b/content/cohorts/index.md
@@ -18,8 +18,64 @@ Submissions are now closed, but will reopen in March 2022 for a second round.
 
 ## The Cohorts
 
-We will be introducing teams shortly! 
+---
 
+**AWAC2 Analysing Web Archives of the COVID Crisis through the IIPC Novel Coronavirus dataset**
+
+* Valérie Schafer, University of Luxembourg (LU)
+* Karin De Wild, Leiden University (NL)
+* Frédéric Clavert, University of Luxembourg (LU)
+* Niels Brügger, Aarhus University (DK)
+* Susan Aasman, University of Groningen (NL)
+* Sophie Gebeil, University of Aix-Marseille (FR)
+
+Investigating transnational events through web archive collections, the AWAC2 team will focus on a distant reading of the IIPC COVID-19 web archival collection to understand actors, content types and interconnectivity throughout it.
+
+---
+
+**Everything Old is New Again: A Comparative Analysis of Feminist Media Tactics between the 2nd- to 4th Waves** 
+
+* Shana MacDonald, University of Waterloo
+* Aynur Kadir, University of Waterloo
+* Brianna Wiens, York University
+* Sid Heeg, University of Waterloo
+
+Project members will explore web archive collections to conduct a comparative analysis of the history of feminist media practices across interdisciplinary multi-media sources. The team expects to produce a timeline of issue responses from different historical moments and map different feminist media practices over this timeline to determine overlaps. The project's key outcome will be to recover earlier feminist media practices and contextualize them in the digital present.
+
+---
+
+**Mapping and tracking the development of online commenting systems on news websites between 1996–2021**
+
+* Anne Helmond, University of Amsterdam/University of Siegen
+* Johannes Paßmann, University of Siegen
+* Robert Jansma, University of Siegen
+* Luca Hammer, University of Siegen
+* Lisa Gerzen, University of Siegen
+
+This project aims to reconstruct a history of online commenting by examining the role of commenting technologies in the popularisation of commenting practices. It will do so by examining the distribution and evolution of commenting technologies on the top 25 Dutch, German, and world news websites from 1996–2021, to understand how they have shaped the practices of users. This will allow them to explore the interplay between technologies and practices of the past and to investigate histories of natively-born technologies and practices.
+
+---
+
+**Crisis Communication in the Niagara Region during the COVID-19 Pandemic**
+
+* Tim Ribaric, Brock University
+* David Sharron, Brock University
+* Cal Murgu, Brock University
+* Karen Louise Smith, Brock University
+* Duncan Koerber, Brock University
+
+Using web archives collected by Brock University, this project will examine how organizations in the Niagara region have responded to government COVID-19 mandates. Analysis will focus on investigating three types of entities: local government, non-profit organizations, and major private entities. Findings from this research aim to inform future crisis communication organizational planning, specifically at the local and municipal level. The project will also create several open computational notebooks to support teaching, learning, and research.
+
+---
+
+**Viral health misinformation from Geocities to COVID-19**
+
+* Shawn Walker, Arizona State University
+* Michael Simeone, Arizona State University
+* Kristy Roschke, Arizona State University
+* Anna Muldoon, Arizona State University
+
+This project will examine and compare two case studies of health misinformation: HIV mis/disinformation circulating on Geocities in the mid-1990s to early 2000s with the role of official COVID-19 Dashboards in COVID mis/disinformation. This work contributes to our understanding of current and historical health misinformation as well as the connections between them, and will also garner insights into how historical narratives of health misinformation have been recycled and repurposed.
 
 ## Organizers & Sponsors
 


### PR DESCRIPTION
Addresses issue [#205](https://github.com/archivesunleashed/archivesunleashed.org/issues/205), to add in cohort groups (team and project descriptions) to cohort page on AU site

Medium post will be published: Wed June 2